### PR TITLE
Support Ubuntu 12.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,7 @@ class consul_template::params {
 
   $init_style = $facts['os']['name'] ? {
     'Ubuntu' => $facts['os']['release']['major'] ? {
+      '12.04' => 'upstart',
       '14.04' => 'upstart',
       default => 'systemd'
     },


### PR DESCRIPTION
I know Ubuntu 12.04 has been EOL 2 years ago but we do have some servers that still run on it.