### PR TITLE
custom systemd unit files should always go in /etc, not lib

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -66,7 +66,7 @@ class consul_template::install {
         }
       }
       'systemd' : {
-        file { '/lib/systemd/system/consul-template.service':
+        file { '/etc/systemd/system/consul-template.service':
           mode    => '0644',
           owner   => 'root',
           group   => 'root',


### PR DESCRIPTION
Simple fix for systemd unit file management. Systemd best practices are to use `/etc/systemd/system` for any custom unit files. Unit files in /etc override any existing /lib unit files and prevent package changes from interfering with your custom unit file.
