### PR TITLE
add arm64/aarch64 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,10 @@ class consul_template::params {
       $arch = '386'
     }
 
+    'aarch64': {
+      $arch = 'arm64'
+    }
+
     default:           {
       fail("Unsupported kernel architecture: ${facts['architecture']}")
     }


### PR DESCRIPTION
Add support for `arm64`/`aarch64`.

I didn't see any arch-specific tests, but this works fine locally.