### PR TITLE
Move systemd service unit to /etc and reload daemon

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -66,7 +66,7 @@ class consul_template::install {
         }
       }
       'systemd' : {
-        file { '/lib/systemd/system/consul-template.service':
+        file { '/etc/systemd/system/consul-template.service':
           mode    => '0644',
           owner   => 'root',
           group   => 'root',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -71,6 +71,15 @@ class consul_template::install {
           owner   => 'root',
           group   => 'root',
           content => template('consul_template/consul-template.systemd.erb'),
+          notify  => Exec['systemctl daemon-reload'],
+        }
+        if (!defined(Exec['systemctl daemon-reload'])) {
+          exec { 'systemctl daemon-reload':
+            command     => 'systemctl daemon-reload',
+            path        => '/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin',
+            refreshonly => true,
+            before      => Service['consul-template'],
+          }
         }
       }
       'sysv' : {


### PR DESCRIPTION
Units in /lib should be deployed by packages. Files with customizations should be written to /etc.
When a systemd unit is customized, the daemon has to be reloaded.